### PR TITLE
fix local env jest testing

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  runner: '@codejedi365/jest-serial-runner'
 };

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "node": ">=10"
   },
   "devDependencies": {
+    "@codejedi365/jest-serial-runner": "^2.0.0",
     "@ethereum-waffle/jest": "^3.3.0",
     "@ethersproject/abstract-signer": "^5.0.7",
     "@ethersproject/address": "^5.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -303,6 +303,11 @@
   dependencies:
     ethers "^5.4.7"
 
+"@codejedi365/jest-serial-runner@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@codejedi365/jest-serial-runner/-/jest-serial-runner-2.0.0.tgz#6bf2b53ef6027fa945c88fc7e022c1eb781cf445"
+  integrity sha512-vP4uulc1EMvwh3xO1RZifTG37/geSoXmaiZQSsH1+CoAN8KxT12NYiEXNmNzpORuz6ui5MI7lLN879Lq6d2RgA==
+
 "@cspotcode/source-map-consumer@0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz#33bf4b7b39c178821606f669bbc447a6a629786b"


### PR DESCRIPTION
[Linear Issue](https://linear.app/catalogworks/issue/CAT-411/fix-local-jest-testing)
###### DESCRIPTION
This small PR adds a serial test runner to the jest configuration, and solves the problem of overlapping/out of sync transaction nonces in the test suite (when ran locally). 

No breaking or major changes are introduced, just an additional package and config line.

###### HOW TO TEST

Run `yarn test` locally (`yarn chain` in another window first) and ensure all tests pass/no transaction nonces fall out of sync. 
